### PR TITLE
`view` outputs filled polygons

### DIFF
--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -56,7 +56,7 @@ def show_polygons(polygons, labels=None, color_map=None):
 
     for i, p in enumerate(polygons):
         x, y = p.exterior.xy
-        ax.plot(x, y, color=color_map[labels[i]])
+        ax.fill(x, y, color=color_map[labels[i]])
         for interior in p.interiors:
             x, y = interior.xy
             ax.plot(x, y, color=color_map[labels[i]])

--- a/src/view.py
+++ b/src/view.py
@@ -2,7 +2,7 @@ import click
 
 import geopandas as gpd
 
-import utils.visualization as viz
+from .utils.visualization import show_polygons
 
 
 @click.command()
@@ -31,7 +31,7 @@ def cli(file, label_name):
             polygons.append(shape)
             labels.append(label)
 
-    viz.show_polygons(polygons, labels)
+    show_polygons(polygons, labels)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR modifies the `view` CLI tool to output an image with filled polygons, which helps better differentiate between shapes.

I had a shapefile I created through the geopolygonizer.

I ran `python3 -m src.view --file data/output.shp --label-name label` and got the following:
![view_output](https://github.com/rainflame/geopolygonize/assets/31460433/9a36d97e-f337-4af6-8563-a7baf5f16384)
