### PR TITLE
Tiler only knows about tiling

### DIFF
--- a/src/geopolygonize.py
+++ b/src/geopolygonize.py
@@ -95,25 +95,28 @@ def cli(
     temp_dir = tempfile.mkdtemp()
     try: 
         parameters = VectorizerParameters(
+            input_filepath=input_file,
+            label_name=label_name,
             min_blob_size=min_blob_size,
             pixel_size=pixel_size,
             simplification_pixel_window=simplification_pixel_window,
             smoothing_iterations=smoothing_iterations,
         )
+
         tiler_parameters = TilerParameters(
+            data=parameters.data,
             num_processes=workers,
             tile_size=tile_size,
-            label_name=label_name,
             temp_dir=temp_dir,
         )
         rz = Tiler(
-            input_filepath=input_file,
-            output_filepath=output_file,
             tiler_parameters=tiler_parameters,
             process_tile=process_tile,
             processer_parameters=parameters,
         )
-        rz.process()
+        gdf = rz.process()
+        gdf.to_file(output_file)
+
     except Exception as e:
         raise e
     finally:


### PR DESCRIPTION
Addresses [issue](https://github.com/rainflame/geopolygonize/issues/10).

Tiler used to know information about the data being tiled that was not relevant to tiling. I move this information to be owned by `processing.py`, which yields the `process_tile` and `processer_parameters` used by the tiler.

I explored having the tiler also not own `processer_parameters` by having `processing.py` generate a lambda `process_tile` that already knows about `processor_parameters`, but the `multiprocessing` package has difficulties handling this kind of lambda function.