### PR TITLE
Assume closed instead of ring Boundaries

### DIFF
--- a/src/utils/segmenter/boundary.py
+++ b/src/utils/segmenter/boundary.py
@@ -19,9 +19,6 @@ class Boundary(object):
         idx: int,
         boundary: LineString,
     ) -> None:
-        # A boundary of a polygon is also a ring (closed and simple).
-        # We use Boundary on the cutpoints of a polygon, which may
-        # not result in a simple line, but should result in a closed one.
         assert boundary.is_closed
 
         self.idx = idx
@@ -56,7 +53,7 @@ class Boundary(object):
             self._seg_idx.insert(i, bbox)
 
     def _setup_temporary_variables(self) -> None:
-        self._ring_intersections: Dict[NeighborIdx, LineString] = {}
+        self._closed_intersections: Dict[NeighborIdx, LineString] = {}
         self._intersections: Dict[NeighborIdx, List[LineString]] = {}
 
         # Cutpoints are points that define the endpoints of the segments.
@@ -108,16 +105,16 @@ class Boundary(object):
         self._sort_cache[point] = distance
         return distance
 
-    def add_ring_intersection(
+    def add_closed_intersection(
         self,
         other, #: Boundary,
-        ring: LineString,
+        closed: LineString,
     ) -> None:
-        assert ring.is_ring
-        self._ring_intersections[other.idx] = ring
+        assert closed.is_closed
+        self._closed_intersections[other.idx] = closed
 
-    def get_ring_intersections(self) -> ItemsView[NeighborIdx, LineString]:
-        return self._ring_intersections.items()
+    def get_closed_intersections(self) -> ItemsView[NeighborIdx, LineString]:
+        return self._closed_intersections.items()
 
     def add_intersection(
         self,

--- a/src/utils/segmenter/cutpoints_computer.py
+++ b/src/utils/segmenter/cutpoints_computer.py
@@ -40,7 +40,7 @@ class CutpointsComputer:
             cutpoints = [boundary_start_end]
             for _n, intersection_segments in boundary.get_intersections():
                 for intersection_segment in intersection_segments:
-                    if intersection_segment.is_ring:
+                    if intersection_segment.is_closed:
                         continue
                     start = Point(intersection_segment.coords[0])
                     end = Point(intersection_segment.coords[-1])
@@ -59,7 +59,7 @@ class CutpointsComputer:
 
             intersections = curr_boundary.get_border_intersections()
 
-            keep_all = len(intersections) == 1 and intersections[0].is_ring
+            keep_all = len(intersections) == 1 and intersections[0].is_closed
             if keep_all:
                 for coord in list(curr_boundary.line.coords):
                     cutpoint = Point(coord)

--- a/src/utils/segmenter/intersections_computer.py
+++ b/src/utils/segmenter/intersections_computer.py
@@ -79,9 +79,9 @@ class IntersectionsComputer:
                 break  # reached termination in former half of segment
             unvisited.remove(prev_piece)
 
-        is_ring = len(former_section) > 2 \
+        is_closed = len(former_section) > 2 \
             and Point(former_section[-1]) == piece.start
-        if is_ring:
+        if is_closed:
             latter_section = []
         else:
             curr = piece.end
@@ -130,18 +130,18 @@ class IntersectionsComputer:
         if len(intersection_segments) == 0:
             return
 
-        is_ring = False
+        is_closed = False
         for intersection_segment in intersection_segments:
-            if intersection_segment.is_ring:
-                is_ring = True
+            if intersection_segment.is_closed:
+                is_closed = True
 
-        if is_ring:
+        if is_closed:
             assert len(intersection_segments) == 1, \
-                "If the intersection with another boundary is a "\
-                "ring, expect the ring to be the only intersection."
-            ring = intersection_segments[0]
-            curr.add_ring_intersection(other, ring)
-            other.add_ring_intersection(curr, ring)
+                "If the intersection with another boundary is closed, "\
+                "expect the closed line to be the only intersection."
+            closed = intersection_segments[0]
+            curr.add_closed_intersection(other, closed)
+            other.add_closed_intersection(curr, closed)
         else:
             curr.add_intersection(other, intersection_segments)
             other.add_intersection(curr, intersection_segments)

--- a/src/utils/segmenter/references_computer.py
+++ b/src/utils/segmenter/references_computer.py
@@ -29,11 +29,11 @@ class ReferencesComputer:
         for i, segment in enumerate(curr_boundary.segments):
             curr_boundary.add_potential_reference(segment)
 
-    def _consider_neighbor_for_ring_segments(
+    def _consider_neighbor_for_closed_segments(
         self,
         curr_boundary: Boundary,
     ) -> None:
-        for o, _ring in curr_boundary.get_ring_intersections():
+        for o, _closed in curr_boundary.get_closed_intersections():
             if o <= curr_boundary.idx:
                 continue
             other_boundary = self.boundaries[o]
@@ -99,7 +99,7 @@ class ReferencesComputer:
 
         for b in range(len(self.boundaries)):
             curr_boundary = self.boundaries[b]
-            self._consider_neighbor_for_ring_segments(curr_boundary)
+            self._consider_neighbor_for_closed_segments(curr_boundary)
 
         for b in range(len(self.boundaries)):
             curr_boundary = self.boundaries[b]


### PR DESCRIPTION
We can't guarantee the boundaries of the input polygons we get are rings. However, as far as I can tell, boundaries of polygons must be closed. Given this, we use this less restrictive condition.

A line that is closed is one where the start and end are the same. A ring is a line that is both closed and "simple": it does not self-intersect.