### PR TITLE
downsample TIF inputs

### DIFF
--- a/utilities/downsample.py
+++ b/utilities/downsample.py
@@ -1,0 +1,59 @@
+import click
+
+import rasterio
+from rasterio.enums import Resampling
+
+
+@click.command('reduce resolution of the TIF file')
+@click.option(
+    '-i',
+    '--input-path',
+    required=True,
+    type=str,
+    help='TIF input file path',
+)
+@click.option(
+    '-o',
+    '--output-path',
+    required=True,
+    type=str,
+    help='TIF output file path',
+)
+@click.option(
+    '-r',
+    '--resolution',
+    default=1.0,
+    help='Float in range (0.0, 1.0] to reduce resolution of TIF to.',
+)
+def cli(
+    input_path,
+    output_path,
+    resolution,
+):
+    with rasterio.open(input_path) as src:
+        new_height = int(src.height * resolution)
+        new_width = int(src.width * resolution)
+
+        data = src.read(
+            out_shape=(src.count, new_height, new_width),
+            resampling=Resampling.mode # select pixel that appears most often
+        )
+
+        transform = src.transform * src.transform.scale(
+            (src.width / new_width),
+            (src.height / new_height),
+        )
+
+        profile = src.profile.copy()
+        profile.update({
+            'transform': transform,
+            'height': new_height,
+            'width': new_width
+        })
+
+        with rasterio.open(output_path, 'w', **profile) as dst:
+            dst.write(data)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Addresses issue #63.

The user can change the resolution of their TIF with the new tool introduced with this PR like so:
```
python utilities/downsample.py -i data/<input>.tif -o data/<output>.tif -r <resolution>
```

Then they can use geopolygonize to get the reduced-resolution polygons.

Original
![downsample_original](https://github.com/rainflame/geopolygonize/assets/31460433/6a9ba57f-75c0-4388-8591-d148d71efc49)

50%
![downsample_50](https://github.com/rainflame/geopolygonize/assets/31460433/11453e55-5f8f-4142-9b06-5e75415adda9)

25%
![downsample_25](https://github.com/rainflame/geopolygonize/assets/31460433/d139de31-708e-47c5-b248-e831716b1fe7)
